### PR TITLE
fix: change user key format to twisted edwards

### DIFF
--- a/tplus/evm/eip712.py
+++ b/tplus/evm/eip712.py
@@ -15,6 +15,6 @@ class Order(Domain):
     amountOut: "uint256"  # type: ignore
     tokenIn: "address"  # type: ignore
     amountIn: "uint256"  # type: ignore
-    userPublicKey: "bytes"  # type: ignore
+    user: "bytes32"  # type: ignore
     nonce: "uint256"  # type: ignore
     validUntil: "uint256"  # type: ignore


### PR DESCRIPTION
we're using whacky ed now

corresponding PRs:

https://github.com/tpluslabs/tplus-core/pull/111
https://github.com/tpluslabs/tplus-contracts/pull/29