### PR TITLE
fix: `TxSettlementRequest.create_signed()` accept raw dictionary

### DIFF
--- a/tests/model/conftest.py
+++ b/tests/model/conftest.py
@@ -1,0 +1,8 @@
+import pytest
+
+from tplus.utils.user import User
+
+
+@pytest.fixture(scope="session")
+def user():
+    return User()

--- a/tests/model/test_settlement.py
+++ b/tests/model/test_settlement.py
@@ -1,50 +1,61 @@
+import pytest
+
 from tplus.model.asset_identifier import AssetIdentifier
 from tplus.model.settlement import (
     BundleSettlementRequest,
     TxSettlementRequest,
 )
+from tplus.utils.hex import to_vec
 
 CHAIN_ID = 11155111
 ASSET_IN = "0x62622E77D1349Face943C6e7D5c01C61465FE1dc"
 ASSET_OUT = "0x58372ab62269A52fA636aD7F200d93999595DCAF"
-SETTLER = "0xeb886a56f9f0efa64432678cebf1270e9314a758e6eb697a606202a451e3e82e"
 
 
 class TestTxSettlementRequest:
-    def test_signing_payload(self):
-        """
-        Show we serialize to the JSON the clearing-engine expects.
-        """
-        settlement = {
-            "tplus_user": SETTLER,
+    @pytest.fixture(scope="class")
+    def settlement(self, user):
+        return {
+            "tplus_user": user.public_key,
             "calldata": [],
             **get_base_settlement_data(),
             "chain_id": CHAIN_ID,
         }
+
+    def test_signing_payload(self, settlement, user):
+        """
+        Show we serialize to the JSON the clearing-engine expects.
+        """
         settlement = TxSettlementRequest(inner=settlement, signature=[])
         actual = settlement.signing_payload()
-        expected = '{"tplus_user":[235,136,106,86,249,240,239,166,68,50,103,140,235,241,39,14,147,20,167,88,230,235,105,122,96,98,2,164,81,227,232,46],"calldata":[],"asset_in":"62622e77d1349face943c6e7d5c01c61465fe1dc000000000000000000000000@0000000000aa36a7","amount_in":"0x64","asset_out":"58372ab62269a52fa636ad7f200d93999595dcaf000000000000000000000000@0000000000aa36a7","amount_out":"0x64","chain_id":[0,0,0,0,0,170,54,167]}'
+        expected_user = f"{to_vec(user.public_key)}".replace(" ", "")
+        expected = f'{{"tplus_user":{expected_user},"calldata":[],"asset_in":"62622e77d1349face943c6e7d5c01c61465fe1dc000000000000000000000000@0000000000aa36a7","amount_in":"0x64","asset_out":"58372ab62269a52fa636ad7f200d93999595dcaf000000000000000000000000@0000000000aa36a7","amount_out":"0x64","chain_id":[0,0,0,0,0,170,54,167]}}'
         assert actual == expected
 
         # Show it is the same as the inner version.
         actual = settlement.inner.signing_payload()
         assert actual == expected
 
+    def test_from_signed(self, settlement, user):
+        settlement = TxSettlementRequest.create_signed(settlement, user)
+        assert settlement.signature  # truthiness
+
 
 class TestBundleSettlementRequest:
-    def test_signing_payload(self):
+    def test_signing_payload(self, user):
         """
         Show we serialize to the JSON the clearing-engine expects.
         """
         inner = {
             "settlements": [get_base_settlement_data()],
             "bundle": {"bundle": {}, "bundle_id": 0},
-            "tplus_user": SETTLER,
+            "tplus_user": user.public_key,
             "chain_id": CHAIN_ID,
         }
         settlement = BundleSettlementRequest(inner=inner, signature=[])
         actual = settlement.signing_payload()
-        expected = '{"settlements":[{"asset_in":"62622e77d1349face943c6e7d5c01c61465fe1dc000000000000000000000000@0000000000aa36a7","amount_in":"0x64","asset_out":"58372ab62269a52fa636ad7f200d93999595dcaf000000000000000000000000@0000000000aa36a7","amount_out":"0x64"}],"bundle":{"bundle":{},"bundle_id":0},"chain_id":[0,0,0,0,0,170,54,167],"tplus_user":[235,136,106,86,249,240,239,166,68,50,103,140,235,241,39,14,147,20,167,88,230,235,105,122,96,98,2,164,81,227,232,46]}'
+        expected_user = f"{to_vec(user.public_key)}".replace(" ", "")
+        expected = f'{{"settlements":[{{"asset_in":"62622e77d1349face943c6e7d5c01c61465fe1dc000000000000000000000000@0000000000aa36a7","amount_in":"0x64","asset_out":"58372ab62269a52fa636ad7f200d93999595dcaf000000000000000000000000@0000000000aa36a7","amount_out":"0x64"}}],"bundle":{{"bundle":{{}},"bundle_id":0}},"chain_id":[0,0,0,0,0,170,54,167],"tplus_user":{expected_user}}}'
         assert actual == expected
 
 

--- a/tplus/model/settlement.py
+++ b/tplus/model/settlement.py
@@ -12,59 +12,6 @@ if TYPE_CHECKING:
     from tplus.utils.user import User
 
 
-class TxSettlementRequest(BaseModel):
-    """
-    Atomic settlement request.
-    """
-
-    inner: "InnerSettlementRequest"
-    """
-    The inner part of the request (signature fields).
-    """
-
-    signature: list[int]
-    """
-    The settler's signature from signing the necessary data (mostly from ``.inner``).
-    """
-
-    @classmethod
-    def create_signed(
-        cls, inner: "InnerSettlementRequest", signer: "User"
-    ) -> "TxSettlementRequest":
-        signature = str_to_vec(signer.sign(inner.signing_payload()).hex())
-        return cls(inner=inner, signature=signature)
-
-    def signing_payload(self) -> str:
-        return self.inner.signing_payload()
-
-
-class BundleSettlementRequest(BaseModel):
-    """
-    Bundle settlement request.
-    """
-
-    inner: "InnerBundleSettlementRequest"
-    """
-    The inner part of the request (signature fields).
-    Allows multiple settlements, unlike ``TxSettlementRequest``.
-    """
-
-    signature: list[int]
-    """
-    The settler's signature from signing the necessary data (mostly from ``.inner``).
-    """
-
-    @classmethod
-    def create_signed(
-        cls, inner: "InnerBundleSettlementRequest", signer: "User"
-    ) -> "BundleSettlementRequest":
-        signature = str_to_vec(signer.sign(inner.signing_payload()).hex())
-        return cls(inner=inner, signature=signature)
-
-    def signing_payload(self) -> str:
-        return self.inner.signing_payload()
-
-
 class BaseSettlement(BaseModel):
     """
     The shared fields for all inner settlement requests.
@@ -102,6 +49,62 @@ class InnerSettlementRequest(BaseSettlement):
         }
 
         return json.dumps(payload).replace(" ", "").replace("\r", "").replace("\n", "")
+
+
+class TxSettlementRequest(BaseModel):
+    """
+    Atomic settlement request.
+    """
+
+    inner: InnerSettlementRequest
+    """
+    The inner part of the request (signature fields).
+    """
+
+    signature: list[int]
+    """
+    The settler's signature from signing the necessary data (mostly from ``.inner``).
+    """
+
+    @classmethod
+    def create_signed(
+        cls, inner: InnerSettlementRequest | dict, signer: "User"
+    ) -> "TxSettlementRequest":
+        if isinstance(inner, dict):
+            inner = InnerSettlementRequest.model_validate(inner)
+
+        signature = str_to_vec(signer.sign(inner.signing_payload()).hex())
+        return cls(inner=inner, signature=signature)
+
+    def signing_payload(self) -> str:
+        return self.inner.signing_payload()
+
+
+class BundleSettlementRequest(BaseModel):
+    """
+    Bundle settlement request.
+    """
+
+    inner: "InnerBundleSettlementRequest"
+    """
+    The inner part of the request (signature fields).
+    Allows multiple settlements, unlike ``TxSettlementRequest``.
+    """
+
+    signature: list[int]
+    """
+    The settler's signature from signing the necessary data (mostly from ``.inner``).
+    """
+
+    @classmethod
+    def create_signed(
+        cls, inner: "InnerBundleSettlementRequest", signer: "User"
+    ) -> "BundleSettlementRequest":
+        signature = str_to_vec(signer.sign(inner.signing_payload()).hex())
+        return cls(inner=inner, signature=signature)
+
+    def signing_payload(self) -> str:
+        return self.inner.signing_payload()
 
 
 class InnerBundleSettlementRequest(BaseModel):


### PR DESCRIPTION
Allows using `TxSettlementRequest.create_signed()` to accept a raw dictionary for the inner argument, makes it easier to quickly create settlement requests