### PR TITLE
fix: PyPI publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,14 +1,14 @@
 name: Publish Python Package
 
 on:
-  push:
-    branches: [main]
+  release:
+    types: [released]
 
 jobs:
   build-and-publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -20,10 +20,10 @@ jobs:
           python -m pip install --upgrade setuptools wheel
           python setup.py sdist bdist_wheel
 
-      - name: Publish to GitHub Packages
+      - name: Publish to PYPI
         run: |
           python -m pip install --upgrade twine
-          twine upload --repository-url https://upload.pypi.github.com/ dist/*
+          twine upload dist/*
         env:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Python
         uses: actions/setup-python@v5


### PR DESCRIPTION
we should be uploading to pypi directly, i think using gh like this is an older legacy approach that isnt even working for me anymore