### PR TITLE
fix: pass settler param to executeAtomicSettlement

### DIFF
--- a/tplus/evm/contracts.py
+++ b/tplus/evm/contracts.py
@@ -520,12 +520,15 @@ class DepositVault(TPlusContract):
     def execute_atomic_settlement(
         self,
         settlement: dict,
+        settler: HexBytes,
         data: HexBytes,
         signature: HexBytes,
         **tx_kwargs,
     ) -> "ReceiptAPI":
         try:
-            return self.contract.executeAtomicSettlement(settlement, data, signature, **tx_kwargs)
+            return self.contract.executeAtomicSettlement(
+                settlement, settler, data, signature, **tx_kwargs
+            )
         except Exception as err:
             err_id = getattr(err, "message", "")
             if erc20_err_name := _decode_erc20_error(getattr(err, "message", f"{err}")):

--- a/tplus/evm/managers/settle.py
+++ b/tplus/evm/managers/settle.py
@@ -360,6 +360,7 @@ class SettlementManager(ChainConnectedManager):
                 "nonce": nonce,
                 "validUntil": expiry,
             },
+            HexBytes(user.public_key),
             "",
             HexBytes(approval.inner.signature),
             **kwargs,


### PR DESCRIPTION
## Summary
- Contract manifest was updated (#162) to add `settler` (bytes32) to `executeAtomicSettlement` ABI
- Python code in `contracts.py` and `settle.py` was not updated to pass it
- This causes `ArgumentsLengthError` on any E2E settlement test

## Changes
- `contracts.py`: Add `settler` parameter to `execute_atomic_settlement`
- `settle.py`: Pass `user.public_key` as the settler when executing on-chain

## Test plan
- Unblocks tplus-core PR #953 E2E settlement tests (split 6)