### PR TITLE
Add OrderRemovedEvent for the orderbook stream

### DIFF
--- a/tests/model/test_order_events.py
+++ b/tests/model/test_order_events.py
@@ -1,0 +1,65 @@
+from tplus.model.asset_identifier import AssetIdentifier
+from tplus.model.order import (
+    OrderRemovedEvent,
+    parse_order_event,
+)
+
+
+def test_parse_order_removed_event_completed():
+    payload = {
+        "Removed": {
+            "order_id": "rt6G7V8gRAG4p7lfidkeUw==",
+            "asset_id": "82af49447d8a07e3bd95bd0d56f35241523fbab1000000000000000000000000@00000000000000a4b1",
+            "user_id": "0xabc",
+            "timestamp_ns": 1750146943779456128,
+            "operator_pubkey": "0xdef",
+            "reason": "Completed",
+            "filled_quantity": 100,
+            "filled_amount": 200,
+            "confirmed_quantity": 100,
+            "confirmed_amount": 200,
+            "book_quantity_decimals": 8,
+        }
+    }
+
+    event = parse_order_event(payload)
+
+    assert isinstance(event, OrderRemovedEvent)
+    assert event.event_type == "REMOVED"
+    assert event.order_id == "rt6G7V8gRAG4p7lfidkeUw=="
+    assert event.asset_id == AssetIdentifier(
+        "82af49447d8a07e3bd95bd0d56f35241523fbab1000000000000000000000000@00000000000000a4b1"
+    )
+    assert event.user_id == "0xabc"
+    assert event.timestamp_ns == 1750146943779456128
+    assert event.operator_pubkey == "0xdef"
+    assert event.reason == "Completed"
+    assert event.filled_quantity == 100
+    assert event.filled_amount == 200
+    assert event.confirmed_quantity == 100
+    assert event.confirmed_amount == 200
+    assert event.book_quantity_decimals == 8
+
+
+def test_parse_order_removed_event_canceled():
+    payload = {
+        "Removed": {
+            "order_id": "abc",
+            "asset_id": "82af49447d8a07e3bd95bd0d56f35241523fbab1000000000000000000000000@00000000000000a4b1",
+            "user_id": "u",
+            "timestamp_ns": 0,
+            "operator_pubkey": "p",
+            "reason": "Canceled",
+            "filled_quantity": 0,
+            "filled_amount": 0,
+            "confirmed_quantity": 0,
+            "confirmed_amount": 0,
+            "book_quantity_decimals": 0,
+        }
+    }
+
+    event = parse_order_event(payload)
+
+    assert isinstance(event, OrderRemovedEvent)
+    assert event.reason == "Canceled"
+    assert event.filled_quantity == 0

--- a/tplus/model/order.py
+++ b/tplus/model/order.py
@@ -198,6 +198,21 @@ class OrderCancelFailedEvent(BaseOrderEvent):
     reason: str | None = None
 
 
+class OrderRemovedEvent(BaseOrderEvent):
+    event_type: Literal["REMOVED"]
+    order_id: str
+    asset_id: AssetIdentifier
+    user_id: str
+    timestamp_ns: int
+    operator_pubkey: str
+    reason: str
+    filled_quantity: int
+    filled_amount: int
+    confirmed_quantity: int
+    confirmed_amount: int
+    book_quantity_decimals: int
+
+
 OrderEvent = (
     OrderCreatedEvent
     | OrderUpdatedEvent
@@ -206,6 +221,7 @@ OrderEvent = (
     | OrderCreateFailedEvent
     | OrderReplaceFailedEvent
     | OrderCancelFailedEvent
+    | OrderRemovedEvent
 )
 
 
@@ -217,6 +233,7 @@ _EVENT_TYPE_MODEL_MAP: dict[str, type[BaseOrderEvent]] = {
     "CREATEFAILED": OrderCreateFailedEvent,
     "REPLACEFAILED": OrderReplaceFailedEvent,
     "CANCELFAILED": OrderCancelFailedEvent,
+    "REMOVED": OrderRemovedEvent,
 }
 
 


### PR DESCRIPTION
## Summary

tplus-core emits a `Removed` variant on `/orders` for every order that leaves the book — fully filled, canceled, GTD-expired, or rejected by the clearing engine (see [`tplus-core/messages/orderbook_messages/src/events/order_removed.rs`](../../tpluslabs/tplus-core/blob/main/messages/orderbook_messages/src/events/order_removed.rs)). The Python order-event parser was missing this model, so each `Removed` event raised `"Unknown order event type: Removed"` inside `BaseClient._stream_ws` and was silently dropped — masking real order-removal state from downstream consumers.

This PR adds `OrderRemovedEvent` matching the Rust `OrderRemoved` struct field-for-field, registers it in `_EVENT_TYPE_MODEL_MAP["REMOVED"]`, and includes it in the `OrderEvent` union.

`reason` is the `OrderRemovalReason` variant serialized as its name string (`"Completed"`, `"Canceled"`, `"Expired"`, `"Rejected"`).

## Test plan

- [x] New tests in `tests/model/test_order_events.py` cover `parse_order_event` against both a fully-filled (`"Completed"`) and a zero-fill (`"Canceled"`) Removed payload — both pass.
- [x] Verified downstream against the `tplus-integrations` SDK consumer: 27 stream-orders tests pass after dropping the local `_order_removed.py` workaround that previously monkey-patched this same registration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)