### PR TITLE
ci: add workflow_dispatch trigger for python-review-caller

### DIFF
--- a/.github/workflows/python-review-caller.yml
+++ b/.github/workflows/python-review-caller.yml
@@ -3,11 +3,22 @@ name: Python SDK Review
 on:
   pull_request:
     types: [opened]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: PR number to review
+        required: true
+        type: string
 
 jobs:
   python-review:
-    if: contains(fromJSON('["manore993","aleks-tplus","antazoey","carlosdimatteo","deadeagle63","emmick4","farnyser","heytdep","jakubcech","jmcph4","juliakroger","markuspluna"]'), github.event.pull_request.user.login)
+    # On PR events the author allowlist gates the run. On workflow_dispatch the
+    # gate is who can dispatch the workflow (repo write access), so the allowlist
+    # is bypassed for manual triggers.
+    if: github.event_name == 'workflow_dispatch' || contains(fromJSON('["manore993","aleks-tplus","antazoey","carlosdimatteo","deadeagle63","emmick4","farnyser","heytdep","jakubcech","jmcph4","juliakroger","markuspluna"]'), github.event.pull_request.user.login)
     uses: tpluslabs/claude-auditor/.github/workflows/python-review.yml@main
+    with:
+      pr_number: ${{ github.event.inputs.pr_number || github.event.pull_request.number }}
     secrets:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
       AUDITOR_APP_ID: ${{ secrets.AUDITOR_APP_ID }}


### PR DESCRIPTION
## Summary

- Add `workflow_dispatch` trigger (with required `pr_number` input) to `python-review-caller.yml` so reviews can be manually re-fired when the on-opened hook misses or fails.
- Pass `pr_number` to the reusable workflow via `with:` for both PR events and dispatch events.
- Mirrors the manual pattern already in `tplus-services/security-audit-manual.yml`.

## Why

A handful of recent open PRs (including #172) never got a Python SDK review because the `pull_request: opened` event silently failed once and the workflow has no retry path. tplus-services solved this with a manual-dispatch workflow; this brings the same capability here.

## Dependency

Requires tpluslabs/claude-auditor#12 to be merged first (adds the optional `pr_number` input to the reusable workflow). Until then, the dispatch path will fail at workflow validation.

## Test plan

- [ ] After merge: dispatch on #172 via Actions tab to confirm end-to-end manual run works
- [ ] Confirm PR events still fire normally (open a fresh PR or rely on next PR opened)

🤖 Generated with [Claude Code](https://claude.com/claude-code)